### PR TITLE
Second attempt at Spidertron Waypoints compatibility

### DIFF
--- a/shortcuts.lua
+++ b/shortcuts.lua
@@ -44,7 +44,7 @@ local item_remote = {
 	type = "spidertron-remote",
 	name = "squad-spidertron-remote",
 	localised_name = "Spidertron squad remote",
-	icon = "__base__/graphics/icons/spidertron-remote.png",
+	icons = {{icon = "__base__/graphics/icons/spidertron-remote.png", tint = {r = 1}}},
 	icon_color_indicator_mask = "__base__/graphics/icons/spidertron-remote-mask.png",
 	icon_size = 64, icon_mipmaps = 4,
 	subgroup = "other",


### PR DESCRIPTION
Follow on from #1, this branch is taken from dev, not master.
It only works with https://github.com/tburrows13/SpidertronWaypoints/commit/99b5bc0494a06685bb56d056c7068a862ddade7e and later (which is not on the mod portal yet - will be version 1.3.2 or 1.4.0).

As noted in https://mods.factorio.com/mod/Spider_Control/discussion/5f4ecaa695a64b92bcc694ba, I have removed that big section of code. If it is actually needed, it can be readded, but would probably need disabling/limiting when SpidertronWaypoints is active.

Squad patrols and waypoints are now working, but it only works with one at a time, presumably because you only store one squad at once. This will need changing. There's still a way to go :)